### PR TITLE
Use ruby 1.9.3 p547 to prevent debugger failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,8 @@ RUN curl -L https://get.rvm.io | bash -s stable --ruby
 RUN echo 'source /usr/local/rvm/scripts/rvm' >> /etc/bash.bashrc
 RUN /bin/bash -l -c rvm requirements
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-RUN /bin/bash -l -c 'rvm install 1.9.3'
-RUN /bin/bash -l -c 'rvm use 1.9.3 --default'
+RUN /bin/bash -l -c 'rvm install 1.9.3-p547 --patch railsexpress'
+RUN /bin/bash -l -c 'rvm use 1.9.3-p547 --default'
 RUN /bin/bash -l -c 'gem install bundle archive-tar-minitar'
 
 # Install bundler


### PR DESCRIPTION
In debugger-ruby_core_source 1.3.7 this was fixed https://github.com/cldwalker/debugger-ruby_core_source/pull/42 for ruby  1.9.3-p551
