### PR TITLE
Pin postgresql-cartodb version to 0.4.1 to avoid errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN service postgresql start && /bin/su postgres -c \
       /tmp/template_postgis.sh && service postgresql stop
 
 # Install cartodb extension
-RUN git clone https://github.com/CartoDB/cartodb-postgresql && \
+RUN git clone --branch 0.4.1 https://github.com/CartoDB/cartodb-postgresql && \
       cd cartodb-postgresql && \
       PGUSER=postgres make install
 ADD ./cartodb_pgsql.sh /tmp/cartodb_pgsql.sh


### PR DESCRIPTION
Hi @fleu42, 

I found that installing the leading edge cartodb-postgresql now causes errors. I pinned to version 0.4.1 which fixes the error I was encountering. 

Thanks,
Noah
