### PR TITLE
Pin postgresql-cartodb version to 0.5.1 to avoid errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN service postgresql start && /bin/su postgres -c \
       /tmp/template_postgis.sh && service postgresql stop
 
 # Install cartodb extension
-RUN git clone --branch 0.5.0 https://github.com/CartoDB/cartodb-postgresql && \
+RUN git clone --branch 0.5.1 https://github.com/CartoDB/cartodb-postgresql && \
       cd cartodb-postgresql && \
       PGUSER=postgres make install
 ADD ./cartodb_pgsql.sh /tmp/cartodb_pgsql.sh


### PR DESCRIPTION
Hi @fleu42,

It's the same issue reported and fixed by @noahg, but this time the right version  for cartodb-postgresql  is 0.5.1

Cheers,
Jorge
